### PR TITLE
Refactor PrintShape to simplify point assignment in image

### DIFF
--- a/src/PrintShape.cpp
+++ b/src/PrintShape.cpp
@@ -40,10 +40,8 @@ void PrintShape::operator()(int rows) const {
     // Iterate through each point in the image
     for (int i = -rows + 1; i < rows; i++) {
         for (int j = -rows + 1; j < rows; j++) {
-            // Check if the point is inside the shape
-            if (insideShape(rows, i, j)) {
-                image[i + rows - 1][j + rows - 1] = true;
-            }
+            // Set the point to true if it is inside the shape
+            image[i + rows - 1][j + rows - 1] = insideShape(rows, i, j);
         }
     }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `PrintShape` class in the `src/PrintShape.cpp` file. The change simplifies the logic for setting points inside the shape.

* [`src/PrintShape.cpp`](diffhunk://#diff-c250e79e64b479f4fdf2ddb1f75f782a43487c12cabd38406246507671c46183L43-R44): Simplified the logic in `void PrintShape::operator()(int rows) const` by directly assigning the result of `insideShape(rows, i, j)` to `image[i + rows - 1][j + rows - 1]`.